### PR TITLE
Fix manual generation of config.json

### DIFF
--- a/hooks/generate-config.py
+++ b/hooks/generate-config.py
@@ -11,7 +11,6 @@ log.basicConfig(level=log.INFO, stream=sys.stderr)
 config_file_path = sys.argv[1] if len(sys.argv) > 1 else path.join(path.expanduser('~'), '.docker', 'config.json')  
 config = {}
 
-
 if path.exists(config_file_path):
     try:
         with open(config_file_path, 'r') as f:
@@ -22,17 +21,18 @@ if path.exists(config_file_path):
 
 log.info(f'Adding container registry to Docker config: %s' % environ['HOSTNAME'])
 
-with open(config_file_path, 'w') as f:
-    if len(config) == 0:
-        config = {
-            'auths': {
-                environ['HOSTNAME']: {
-                    'auth': base64.b64encode(f"{environ['DOCKER_USERNAME']}:{environ['DOCKER_PASSWORD']}".encode('utf-8')).decode('utf-8')
-                }
+if len(config) == 0:
+    config = {
+        'auths': {
+            environ['HOSTNAME']: {
+                'auth': base64.b64encode(f"{environ['DOCKER_USERNAME']}:{environ['DOCKER_PASSWORD']}".encode('utf-8')).decode('utf-8')
             }
         }
-    else:
-        config['auths'][environ['HOSTNAME']] = {
-            'auth': base64.b64encode(f"{environ['DOCKER_USERNAME']}:{environ['DOCKER_PASSWORD']}".encode('utf-8')).decode('utf-8')
-        }
+    }
+else:
+    config['auths'][environ['HOSTNAME']] = {
+        'auth': base64.b64encode(f"{environ['DOCKER_USERNAME']}:{environ['DOCKER_PASSWORD']}".encode('utf-8')).decode('utf-8')
+    }
+
+with open(config_file_path, 'w') as f:
     f.write(json.dumps(config, indent=4))

--- a/hooks/generate-config.py
+++ b/hooks/generate-config.py
@@ -17,7 +17,7 @@ if path.exists(config_file_path):
         with open(config_file_path, 'r') as f:
             config = json.load(f)
     except json.decoder.JSONDecodeError:
-        log.error(f'%s is not valid JSON, overwriting with new content.' % config_file_path)
+        log.warn(f'%s is not valid JSON, overwriting with new content.' % config_file_path)
         config = {}
 
 log.info(f'Adding container registry to Docker config: %s' % environ['HOSTNAME'])

--- a/hooks/generate-config.py
+++ b/hooks/generate-config.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+from os import environ, path
+import base64
+import json
+import logging as log
+import sys
+
+log.basicConfig(level=log.INFO, stream=sys.stderr)
+
+config_file_path = sys.argv[1] if len(sys.argv) > 1 else path.join(path.expanduser('~'), 'config.json')  
+config = {}
+
+
+if path.exists(config_file_path):
+    try:
+        with open(config_file_path, 'r') as f:
+            config = json.load(f)
+    except json.decoder.JSONDecodeError:
+        log.error(f'%s is not valid JSON, overwriting with new content.' % config_file_path)
+        config = {}
+
+log.info(f'Adding container registry to Docker config: %s' % environ['HOSTNAME'])
+
+with open(config_file_path, 'w') as f:
+    if len(config) == 0:
+        config = {
+            'auths': {
+                environ['HOSTNAME']: {
+                    'auth': base64.b64encode(f"{environ['DOCKER_USERNAME']}:{environ['DOCKER_PASSWORD']}".encode('utf-8')).decode('utf-8')
+                }
+            }
+        }
+    else:
+        config['auths'][environ['HOSTNAME']] = {
+            'auth': base64.b64encode(f"{environ['DOCKER_USERNAME']}:{environ['DOCKER_PASSWORD']}".encode('utf-8')).decode('utf-8')
+        }
+    f.write(json.dumps(config, indent=4))

--- a/hooks/generate-config.py
+++ b/hooks/generate-config.py
@@ -8,7 +8,7 @@ import sys
 
 log.basicConfig(level=log.INFO, stream=sys.stderr)
 
-config_file_path = sys.argv[1] if len(sys.argv) > 1 else path.join(path.expanduser('~'), 'config.json')  
+config_file_path = sys.argv[1] if len(sys.argv) > 1 else path.join(path.expanduser('~'), '.docker', 'config.json')  
 config = {}
 
 

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -33,7 +33,7 @@ elif crane version >/dev/null 2>&1; then
     "$HOSTNAME"
 
 else
-  echo "No cli is available to auth. Save creds to /.docker/config.json"
-  mkdir -p ~/.docker && touch ~/.docker/config.json
-  echo '{"auths": {"'"$HOSTNAME"'": {"auth": "'"$(echo "$USERNAME":"$PASSWORD" | base64)"'"}}}' >~/.docker/config.json
+  echo "No cli is available to auth. Save creds to ~/.docker/config.json"
+  mkdir -p ~/.docker
+  $(dirname "${0}")/generate-config.py
 fi


### PR DESCRIPTION
This fixes two issues with the generation of the docker/config.json. This makes the assumption that python is installed... which may or may not be true.

1. The generated JSON is now proper JSON. The previous output would loose the quotes on the key names and values.
2. Fixes a race condition when the plugin is called two times in a pipeline which causes the last credential to be the only credential in the file. The credentials now are appended to the hash each time.