### PR TITLE
Fix the no-cli command

### DIFF
--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -35,5 +35,5 @@ elif crane version >/dev/null 2>&1; then
 else
   echo "No cli is available to auth. Save creds to /.docker/config.json"
   mkdir -p ~/.docker && touch ~/.docker/config.json
-  echo '{"auths": {"'"$HOSTNAME"'": {"auth": "'"$(echo "$USERNAME":"$PASSWORD" | base64)"'"}}}' >~/.docker/config.json
+  echo '{"auths": {"'"$HOSTNAME"'": {"auth": "'"$(echo -n "$USERNAME":"$PASSWORD" | base64 --wrap=0)"'"}}}' >~/.docker/config.json
 fi


### PR DESCRIPTION
This PR fix the command to generate the docker config using echo and base64.

- `echo -n` is used to avoid passing the trailing newline character to base64 command
- `base64 --wrap=0` is used to avoid wraping the base64 encoded auth if it has more than 76 characters