### PR TITLE
Bump plugin version

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ Add the following to your `pipeline.yml`:
 steps:
   - command: ls
     plugins:
-      - elastic/vault-docker-login#v0.3.0:
+      - elastic/vault-docker-login#v0.4.0:
           secret_path: 'secret/ci/elastic-<<your-repo>>/container-registry/<<credentials>>'
 ```


### PR DESCRIPTION
missed it in https://github.com/elastic/vault-docker-login-buildkite-plugin/pull/5