### PR TITLE
Support vault kv engine and default to docker.io if hostname is not set in vault namespace

### DIFF
--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -5,9 +5,18 @@ if ! vault -v >/dev/null 2>&1; then
   exit 1
 fi
 
-REGISTRY_USERNAME=$(vault read -field=username "$BUILDKITE_PLUGIN_VAULT_DOCKER_LOGIN_SECRET_PATH")
-REGISTRY_PASSWORD=$(vault read -field=password "$BUILDKITE_PLUGIN_VAULT_DOCKER_LOGIN_SECRET_PATH")
-REGISTRY_HOSTNAME=$(vault read -field=hostname "$BUILDKITE_PLUGIN_VAULT_DOCKER_LOGIN_SECRET_PATH")
+if [[ "$BUILDKITE_PLUGIN_VAULT_DOCKER_LOGIN_SECRET_PATH" == kv* ]]; then
+  VAULT_METHOD='kv get'
+else
+  VAULT_METHOD='read'
+fi
+
+# shellcheck disable=SC2086
+REGISTRY_USERNAME=$(vault $VAULT_METHOD -field=username "$BUILDKITE_PLUGIN_VAULT_DOCKER_LOGIN_SECRET_PATH")
+# shellcheck disable=SC2086
+REGISTRY_PASSWORD=$(vault $VAULT_METHOD -field=password "$BUILDKITE_PLUGIN_VAULT_DOCKER_LOGIN_SECRET_PATH")
+# shellcheck disable=SC2086
+REGISTRY_HOSTNAME=$(vault $VAULT_METHOD -field=hostname "$BUILDKITE_PLUGIN_VAULT_DOCKER_LOGIN_SECRET_PATH" || echo 'docker.io')
 
 echo "~~~ Log  in to $HOSTNAME container registry"
 

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -18,45 +18,45 @@ REGISTRY_PASSWORD=$(vault $VAULT_METHOD -field=password "$BUILDKITE_PLUGIN_VAULT
 # shellcheck disable=SC2086
 REGISTRY_HOSTNAME=$(vault $VAULT_METHOD -field=hostname "$BUILDKITE_PLUGIN_VAULT_DOCKER_LOGIN_SECRET_PATH" || echo 'docker.io')
 
-echo "~~~ Log  in to $HOSTNAME container registry"
+echo "~~~ Log in to $REGISTRY_HOSTNAME container registry"
 
 if docker --version >/dev/null 2>&1; then
-  echo "Logging to $REGISTRY_HOSTNAME as $REGISTRY_USERNAME with docker cli"
+  echo "Logging in to $REGISTRY_HOSTNAME as $REGISTRY_USERNAME with docker cli"
   docker login \
     --username "$REGISTRY_USERNAME" \
     --password "$REGISTRY_PASSWORD" \
     "$REGISTRY_HOSTNAME"
 
 elif buildah --version >/dev/null 2>&1; then
-  echo "Logging to $REGISTRY_HOSTNAME as $REGISTRY_USERNAME with buildah cli"
+  echo "Logging in to $REGISTRY_HOSTNAME as $REGISTRY_USERNAME with buildah cli"
   buildah login \
     --username "$REGISTRY_USERNAME" \
     --password "$REGISTRY_PASSWORD" \
     "$REGISTRY_HOSTNAME"
 
 elif crane version >/dev/null 2>&1; then
-  echo "Logging to $REGISTRY_HOSTNAME as $REGISTRY_USERNAME with crane cli"
+  echo "Logging in to $REGISTRY_HOSTNAME as $REGISTRY_USERNAME with crane cli"
   crane auth login \
     --username "$REGISTRY_USERNAME" \
     --password "$REGISTRY_PASSWORD" \
     "$REGISTRY_HOSTNAME"
 
 elif cosign version >/dev/null 2>&1; then
-  echo "Logging to $REGISTRY_HOSTNAME as $REGISTRY_USERNAME with cosign cli"
+  echo "Logging in to $REGISTRY_HOSTNAME as $REGISTRY_USERNAME with cosign cli"
   cosign login \
     --username "$REGISTRY_USERNAME" \
     --password "$REGISTRY_PASSWORD" \
     "$REGISTRY_HOSTNAME"
 
 elif podman version >/dev/null 2>&1; then
-  echo "Logging to $REGISTRY_HOSTNAME as $REGISTRY_USERNAME with podman cli"
+  echo "Logging in to $REGISTRY_HOSTNAME as $REGISTRY_USERNAME with podman cli"
   podman login \
     --username "$REGISTRY_USERNAME" \
     --password "$REGISTRY_PASSWORD" \
     "$REGISTRY_HOSTNAME"
 
 elif skopeo version >/dev/null 2>&1; then
-  echo "Logging to $REGISTRY_HOSTNAME as $REGISTRY_USERNAME with skopeo cli"
+  echo "Logging in to $REGISTRY_HOSTNAME as $REGISTRY_USERNAME with skopeo cli"
   skopeo login \
     --username "$REGISTRY_USERNAME" \
     --password "$REGISTRY_PASSWORD" \


### PR DESCRIPTION
There are already some external Docker Hub shared credentials used by Elastic teams using the `kv` engine, this allows support for kv by using `kv get` instead of `read` if the path starts with `kv`.

I also default the registry hostname to `docker.io` as a logical default, which also helps us with shared credentials which don't contain a `hostname` field. :smile: 