### PR TITLE
Add support for Vault kv engine

### DIFF
--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -5,14 +5,23 @@ if ! vault -v >/dev/null 2>&1; then
   exit 1
 fi
 
-REGISTRY_USERNAME=$(vault read -field=username "$BUILDKITE_PLUGIN_VAULT_DOCKER_LOGIN_SECRET_PATH")
-REGISTRY_PASSWORD=$(vault read -field=password "$BUILDKITE_PLUGIN_VAULT_DOCKER_LOGIN_SECRET_PATH")
-REGISTRY_HOSTNAME=$(vault read -field=hostname "$BUILDKITE_PLUGIN_VAULT_DOCKER_LOGIN_SECRET_PATH")
+if [[ "$BUILDKITE_PLUGIN_VAULT_DOCKER_LOGIN_SECRET_PATH" == kv* ]]; then
+  VAULT_METHOD="kv get"
+else
+  VAULT_METHOD="read"
+fi
 
-echo "~~~ Log  in to $REGISTRY_HOSTNAME container registry"
+# shellcheck disable=SC2086
+REGISTRY_USERNAME=$(vault $VAULT_METHOD -field=username "$BUILDKITE_PLUGIN_VAULT_DOCKER_LOGIN_SECRET_PATH")
+# shellcheck disable=SC2086
+REGISTRY_PASSWORD=$(vault $VAULT_METHOD -field=password "$BUILDKITE_PLUGIN_VAULT_DOCKER_LOGIN_SECRET_PATH")
+# shellcheck disable=SC2086
+REGISTRY_HOSTNAME=$(vault $VAULT_METHOD -field=hostname "$BUILDKITE_PLUGIN_VAULT_DOCKER_LOGIN_SECRET_PATH")
+
+echo "~~~ Log in to $REGISTRY_HOSTNAME container registry"
 
 if docker --version >/dev/null 2>&1; then
-  echo "Logging to $REGISTRY_HOSTNAME as $REGISTRY_USERNAME with docker cli"
+  echo "Logging in to $REGISTRY_HOSTNAME as $REGISTRY_USERNAME with docker cli"
   # For dockerhub we must unset the hostname argument during login
   # for credentials to be stored correctly in .docker/config.json
   # See: https://elasticco.atlassian.net/browse/REL-1195
@@ -25,35 +34,35 @@ if docker --version >/dev/null 2>&1; then
     "$REGISTRY_HOSTNAME"
 
 elif buildah --version >/dev/null 2>&1; then
-  echo "Logging to $REGISTRY_HOSTNAME as $REGISTRY_USERNAME with buildah cli"
+  echo "Logging in to $REGISTRY_HOSTNAME as $REGISTRY_USERNAME with buildah cli"
   buildah login \
     --username "$REGISTRY_USERNAME" \
     --password "$REGISTRY_PASSWORD" \
     "$REGISTRY_HOSTNAME"
 
 elif crane version >/dev/null 2>&1; then
-  echo "Logging to $REGISTRY_HOSTNAME as $REGISTRY_USERNAME with crane cli"
+  echo "Logging in to $REGISTRY_HOSTNAME as $REGISTRY_USERNAME with crane cli"
   crane auth login \
     --username "$REGISTRY_USERNAME" \
     --password "$REGISTRY_PASSWORD" \
     "$REGISTRY_HOSTNAME"
 
 elif cosign version >/dev/null 2>&1; then
-  echo "Logging to $REGISTRY_HOSTNAME as $REGISTRY_USERNAME with cosign cli"
+  echo "Logging in to $REGISTRY_HOSTNAME as $REGISTRY_USERNAME with cosign cli"
   cosign login \
     --username "$REGISTRY_USERNAME" \
     --password "$REGISTRY_PASSWORD" \
     "$REGISTRY_HOSTNAME"
 
 elif podman version >/dev/null 2>&1; then
-  echo "Logging to $REGISTRY_HOSTNAME as $REGISTRY_USERNAME with podman cli"
+  echo "Logging in to $REGISTRY_HOSTNAME as $REGISTRY_USERNAME with podman cli"
   podman login \
     --username "$REGISTRY_USERNAME" \
     --password "$REGISTRY_PASSWORD" \
     "$REGISTRY_HOSTNAME"
 
 elif skopeo version >/dev/null 2>&1; then
-  echo "Logging to $REGISTRY_HOSTNAME as $REGISTRY_USERNAME with skopeo cli"
+  echo "Logging in to $REGISTRY_HOSTNAME as $REGISTRY_USERNAME with skopeo cli"
   skopeo login \
     --username "$REGISTRY_USERNAME" \
     --password "$REGISTRY_PASSWORD" \


### PR DESCRIPTION
This PR supersedes https://github.com/elastic/vault-docker-login-buildkite-plugin/pull/11, which in turn superseded https://github.com/elastic/vault-docker-login-buildkite-plugin/pull/8.