### PR TITLE
Use core-ubuntu-2204 instead of unmaintained ci-ubuntu-2204 image

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,4 +9,4 @@ steps:
           id: elastic/vault-docker-login
     agents:
       provider: "gcp"
-      image: family/ci-ubuntu-2204
+      image: family/core-ubuntu-2204

--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ Add the following to your `pipeline.yml`:
 steps:
   - command: ls
     plugins:
-      - elastic/vault-docker-login#v0.5.1:
+      - elastic/vault-docker-login#v0.5.2:
           secret_path: 'secret/ci/elastic-<<your-repo>>/container-registry/<<credentials>>'
 ```


### PR DESCRIPTION
The image family `ci-ubuntu-2204` has been unmaintained for a while and has been replaced by `core-ubuntu-2204`. This PR updates them to this instead.

Related to [incident 505.](https://elastic.slack.com/archives/C078RND5G5C)