### PR TITLE
catalog-info: add robots with build permissions

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -16,6 +16,8 @@ spec:
         publish_commit_status_per_step: false
       repository: elastic/vault-docker-login-buildkite-plugin
       teams:
+        observablt-robots:
+          access_level: BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
         platform-dev-flow: {}


### PR DESCRIPTION
Relax a bit on the permissions so I can try to run things in the CI easily.

See https://github.com/elastic/vault-docker-login-buildkite-plugin/pull/24#issuecomment-2962538220