### PR TITLE
fix: support plugin multiple times

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add the following to your `pipeline.yml`:
 steps:
   - command: ls
     plugins:
-      - elastic/vault-docker-login#v0.5.2:
+      - elastic/vault-docker-login#v0.6.0:
           secret_path: 'secret/ci/elastic-<<your-repo>>/container-registry/<<credentials>>'
           disable_logout: true
 ```

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -1,15 +1,8 @@
 #!/bin/bash
 
-if ! vault -v >/dev/null 2>&1; then
-  echo "Could not find a vault cli to retrieve docker login secrets"
-  exit 1
-fi
-
-if [[ "$BUILDKITE_PLUGIN_VAULT_DOCKER_LOGIN_SECRET_PATH" == kv* ]]; then
-  VAULT_METHOD="kv get"
-else
-  VAULT_METHOD="read"
-fi
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+. "${DIR}/../lib/setup.bash"
 
 # shellcheck disable=SC2086
 REGISTRY_USERNAME=$(vault $VAULT_METHOD -field=username "$BUILDKITE_PLUGIN_VAULT_DOCKER_LOGIN_SECRET_PATH")

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+. "${DIR}/../lib/setup.bash"
+
+# shellcheck disable=SC2086
+REGISTRY_HOSTNAME=$(vault $VAULT_METHOD -field=hostname "$BUILDKITE_PLUGIN_VAULT_DOCKER_LOGIN_SECRET_PATH")
+
 echo "~~~ Log out to $REGISTRY_HOSTNAME container registry"
 
 if [[ "${BUILDKITE_PLUGIN_VAULT_DOCKER_LOGIN_DISABLE_LOGOUT:-false}" = "true" ]]; then

--- a/lib/setup.bash
+++ b/lib/setup.bash
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! vault -v >/dev/null 2>&1; then
+  echo "Could not find a vault cli to retrieve docker login secrets"
+  exit 1
+fi
+
+if [[ "$BUILDKITE_PLUGIN_VAULT_DOCKER_LOGIN_SECRET_PATH" == kv* ]]; then
+  VAULT_METHOD="kv get"
+else
+  # shellcheck disable=SC2034
+  VAULT_METHOD="read"
+fi

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,7 +1,9 @@
 name: Vault Docker Login Buildkite Plugin
 description: Logs into docker with credentials stored in vault
 author: https://github.com/alpar-t
-requirements: []
+requirements:
+  - bash
+  - vault
 configuration:
   properties:
     secret_path:

--- a/tests/pre-command.bats
+++ b/tests/pre-command.bats
@@ -14,8 +14,8 @@ setup () {
     "kv get -field=hostname \* : echo hostname"
 
   stub docker \
-    "exit 0" \
-    "login \* : exit 0"
+    "--version : exit 0" \
+    "login --username username --password password hostname : exit 0"
 }
 
 @test "Clean login execution with kv" {

--- a/tests/pre-exit.bats
+++ b/tests/pre-exit.bats
@@ -4,7 +4,13 @@ setup () {
   load "${BATS_PLUGIN_PATH}/load.bash"
   # export DOCKER_STUB_DEBUG=/dev/tty
 
+  # Add vault stub for pre-exit tests
+  stub vault \
+    "-v : exit 0" \
+    "kv get -field=hostname \* : echo registry.example.com"
+
   export REGISTRY_HOSTNAME="registry.example.com"
+  export BUILDKITE_PLUGIN_VAULT_DOCKER_LOGIN_SECRET_PATH="kv/data/docker-login"
 }
 
 @test "Clean logout execution" {


### PR DESCRIPTION
### What

Support `pre-exit` for multiple instances of the plugin with different docker registries.

```yaml
steps:
  - command: ...
    plugins:
      - elastic/vault-docker-login#v0.6.0:
          secret_path: 'my-secret'
      - elastic/vault-docker-login#v0.6.0:
          secret_path: 'my-other-secret'
```

### Why

The `pre-exit` honours the env variable `REGISTRY_HOSTNAME`, and that's different when using the plugin multiple times

### Example

<img width="714" height="510" alt="image" src="https://github.com/user-attachments/assets/59aa8e27-bf70-42cf-84e0-58e17c46a201" />

### Test

It worked fine [here](https://buildkite.com/elastic/observability-robots-playground/builds/1558#019a16fc-132f-4fce-a418-7680415e33d3)

```yaml
steps:
  - command: true
    agents:
      provider: "gcp"
    plugins:
      - v1v/vault-docker-login#fix/support-multiple-calls:
          secret_path: 'secret/ci/elastic-observability-robots-playground/test/dockerhub'
      - v1v/vault-docker-login#fix/support-multiple-calls:
          secret_path: 'secret/ci/elastic-observability-robots-playground/test/elastic'
```

<img width="996" height="621" alt="image" src="https://github.com/user-attachments/assets/da375ec3-cf51-4413-b6d2-31658519d52a" />
