### PR TITLE
fix: skopeo version check in pre-exit

### DIFF
--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -33,7 +33,7 @@ elif podman version >/dev/null 2>&1; then
   echo "Logging out to $REGISTRY_HOSTNAME with podman cli"
   podman logout "$REGISTRY_HOSTNAME"
 
-elif skopeo version >/dev/null 2>&1; then
+elif skopeo version >/dev/null 2>&1 || skopeo --version >/dev/null 2>&1; then
   echo "Logging out to $REGISTRY_HOSTNAME with skopeo cli"
   skopeo logout "$REGISTRY_HOSTNAME"
 


### PR DESCRIPTION
Latest version of skopeo fails when executing with `version` parameter. The correct way is executing with `--version` 

This PR adds the same changed added to pre-command in https://github.com/elastic/vault-docker-login-buildkite-plugin/pull/31
