### PR TITLE
HOTFIX : Move Vault Calls After Check

### DIFF
--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -5,7 +5,7 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "${DIR}/../lib/setup.bash"
 
 if [[ "${BUILDKITE_PLUGIN_VAULT_DOCKER_LOGIN_DISABLE_LOGOUT:-false}" = "true" ]]; then
-  echo 'WARNING: not logging out'
+  echo '~~~ Skipping container registry logout'
   exit 0
 fi
 

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -4,15 +4,15 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck disable=SC1091
 . "${DIR}/../lib/setup.bash"
 
-# shellcheck disable=SC2086
-REGISTRY_HOSTNAME=$(vault $VAULT_METHOD -field=hostname "$BUILDKITE_PLUGIN_VAULT_DOCKER_LOGIN_SECRET_PATH")
-
-echo "~~~ Log out to $REGISTRY_HOSTNAME container registry"
-
 if [[ "${BUILDKITE_PLUGIN_VAULT_DOCKER_LOGIN_DISABLE_LOGOUT:-false}" = "true" ]]; then
   echo 'WARNING: not logging out'
   exit 0
 fi
+
+# shellcheck disable=SC2086
+REGISTRY_HOSTNAME=$(vault $VAULT_METHOD -field=hostname "$BUILDKITE_PLUGIN_VAULT_DOCKER_LOGIN_SECRET_PATH")
+
+echo "~~~ Log out to $REGISTRY_HOSTNAME container registry"
 
 if docker --version >/dev/null 2>&1; then
   echo "Logging out to $REGISTRY_HOSTNAME with docker cli"


### PR DESCRIPTION
In https://github.com/elastic/chainguard-image-sync/pull/96 we wanted to disable the logout feature as it's not necessary for us to finish our pipeline. After the change,[ the next execution](https://buildkite.com/elastic/chainguard-image-sync/builds/3729/steps/waterfall?jid=019aff8d-577b-44fb-a0c7-843aeeb328f0) still resulted in the same issue (timeout due to the time it takes in the pipeline). We noticed that the call that is failing is the vault call that really should go after the check about whether or not we even should be logging out. This moves it below that check and then continues the normal execution flow.