### PR TITLE
chore: report errors and fix test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,5 +15,5 @@ shellcheck:
 	docker compose run shellcheck
 
 clean:
-	-docker compose \
+	docker compose \
 		rm --force --stop

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,7 @@
 all: lint pre-commit shellcheck tests
 
 tests:
-	docker compose \
-	  run --rm \
-	  	-v "${PWD}:/app" \
-	  	tests
+	docker compose run --rm tests
 
 lint:
 	docker compose run lint

--- a/Makefile
+++ b/Makefile
@@ -3,19 +3,19 @@
 all: lint pre-commit shellcheck tests
 
 tests:
-	-docker compose \
+	docker compose \
 	  run --rm \
 	  	-v "${PWD}:/app" \
 	  	tests
 
 lint:
-	-docker compose run lint
+	docker compose run lint
 
 pre-commit:
-	-.buildkite/scripts/pre-commit.sh
+	.buildkite/scripts/pre-commit.sh
 
 shellcheck:
-	-docker compose run shellcheck
+	docker compose run shellcheck
 
 clean:
 	-docker compose \

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add the following to your `pipeline.yml`:
 steps:
   - command: ls
     plugins:
-      - elastic/vault-docker-login#v0.6.1:
+      - elastic/vault-docker-login#v0.6.4:
           secret_path: 'secret/ci/elastic-<<your-repo>>/container-registry/<<credentials>>'
           disable_logout: true
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.7'
 services:
   tests:
     image: buildkite/plugin-tester:v4.1.1
+    platform: linux/amd64
     volumes:
       - .:/plugin
 

--- a/tests/pre-exit.bats
+++ b/tests/pre-exit.bats
@@ -13,6 +13,13 @@ setup () {
   export BUILDKITE_PLUGIN_VAULT_DOCKER_LOGIN_SECRET_PATH="kv/data/docker-login"
 }
 
+teardown() {
+  unstub vault || true
+  unstub docker || true
+  unstub skopeo || true
+  unstub rm || true
+}
+
 @test "Clean logout execution" {
   stub docker \
     "exit 0" \

--- a/tests/pre-exit.bats
+++ b/tests/pre-exit.bats
@@ -51,5 +51,5 @@ setup () {
   run "$PWD/hooks/pre-exit"
 
   assert_success
-  assert_output --partial 'WARNING: not logging out'
+  assert_output --partial 'Skipping container registry logout'
 }


### PR DESCRIPTION
### What
- Fix test assertion:  to match the actual output
- Makefile error handling: Removed the - prefix from test commands in Makefile so errors are properly reported
- Docker volume mount: Removed the volume override in Makefile to use the correct /plugin mount from docker-compose.yml
- Added platform: linux/amd64 to docker-compose.yml:4 to avoid platform warnings
- Stub cleanup: Added a teardown function to properly clean up test stubs

### Why

Catch errors in the CI
