### PR TITLE
Migration: reassign team ownership to @elastic/ci-systems

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @elastic/platform-dev-flow
+* @elastic/ci-systems

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -20,6 +20,6 @@ spec:
           access_level: BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
-        platform-dev-flow: {}
-  owner: group:platform-dev-flow
+        ci-systems: {}
+  owner: group:ci-systems
   type: buildkite-pipeline


### PR DESCRIPTION
Part of the EngProd GitHub team migration (parent: [#2148](https://github.com/elastic/platform-engineering-productivity/issues/2148), this touchpoint: [#2426](https://github.com/elastic/platform-engineering-productivity/issues/2426)).

**⚠️ DO NOT MERGE** until migration day. PRs are merged in batches grouped by new team owner so the [Terrazzo](https://github.com/elastic/terrazzo) wild plan for each batch can be reviewed and approved independently.


### Files changed

- `CODEOWNERS` (1 line)
- `catalog-info.yaml` (2 lines)

---

Generated by `scripts/github-team-migration/open_repo_prs.py`.